### PR TITLE
Pin networkx dependency

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -453,7 +453,7 @@ COPY --from=pkg /licenses /licenses
 # Setup Python Demos Environment
 RUN dnf install --nodocs -y python39-pip git && dnf clean all
 COPY demos/python_demos/requirements.txt .
-RUN pip3 install --no-cache-dir -r requirements.txt && rm -f requirements.txt
+RUN echo 'networkx<=3.2.1' >> requirements.txt && pip3 install --no-cache-dir -r requirements.txt && rm -f requirements.txt
 
 USER ovms
 ENTRYPOINT ["/ovms/bin/ovms"]


### PR DESCRIPTION
Build fails by pulling in networkx-3.3 which can't run with python 3.9. This pins it to what worked last build.