### PR TITLE
Konflux builds fail on 'g++' commands

### DIFF
--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -289,6 +289,7 @@ RUN bazel build --jobs=$JOBS ${debug_bazel_flags} //src:release_custom_nodes
 
 # OVMS
 ARG OPTIMIZE_BUILDING_TESTS=0
+RUN rm -f /usr/lib64/cmake/OpenSSL/OpenSSLConfig.cmake
 # Builds unit tests together with ovms server in one step
 # It speeds up CI when tests are executed outside of the image building
 # hadolint ignore=SC2046


### PR DESCRIPTION
Turns out there is a bad openssl cmake file. Delete it and it builds fine.
