### PR TITLE
Fix opencl-header installation

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -110,8 +110,8 @@ ARG VERBOSE_LOGS=OFF
 ARG LTO_ENABLE=OFF
 
 # hadolint ignore=DL3041
-RUN dnf install -y https://vault.centos.org/centos/8-stream/PowerTools/x86_64/os/Packages/opencl-headers-2.2-1.20180306gite986688.el8.noarch.rpm && \
-            dnf update -d6 -y && dnf install -d6 -y \
+RUN dnf install -d6 -y \
+            https://vault.centos.org/centos/8-stream/PowerTools/x86_64/os/Packages/opencl-headers-2.2-1.20180306gite986688.el8.noarch.rpm \
             gdb \
             java-11-openjdk-devel \
             tzdata-java \

--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -110,8 +110,8 @@ ARG VERBOSE_LOGS=OFF
 ARG LTO_ENABLE=OFF
 
 # hadolint ignore=DL3041
-RUN dnf install -y https://vault.centos.org/centos/8-stream/PowerTools/x86_64/os/Packages/opencl-headers-2.2-1.20180306gite986688.el8.noarch.rpm && \
-            dnf update -d6 -y && dnf install -d6 -y \
+RUN dnf install -d6 -y \
+            https://vault.centos.org/centos/8-stream/PowerTools/x86_64/os/Packages/opencl-headers-2.2-1.20180306gite986688.el8.noarch.rpm \
             gdb \
             java-11-openjdk-devel \
             tzdata-java \


### PR DESCRIPTION
The code as is installs opencl-headers from rhel8 and immediately does a dnf -y update which immediately overwrites it with rhel 9's version which causes compilation failures.

The fix is to get rid of the dnf -y update because the image was already updated back at the first use of dnf.
