### PR TITLE
CVE update

### DIFF
--- a/.konflux/build-args.conf
+++ b/.konflux/build-args.conf
@@ -1,6 +1,6 @@
 # Base images
-BASE_IMAGE=registry.access.redhat.com/ubi9/ubi:9.6
-RELEASE_BASE_IMAGE=registry.access.redhat.com/ubi9-minimal:9.6
+BASE_IMAGE=registry.access.redhat.com/ubi9/ubi:9.7
+RELEASE_BASE_IMAGE=registry.access.redhat.com/ubi9-minimal:9.7
 
 # Logging/tests
 VERBOSE_LOGS=ON
@@ -13,7 +13,7 @@ GPU=1
 ov_use_binary=0
 
 # Versions / LTO
-INSTALL_DRIVER_VERSION=25.05.32567
+INSTALL_DRIVER_VERSION=24.52.32224
 LTO_ENABLE=ON
 LTO_CXX_FLAGS=-flto=auto -ffat-lto-objects -march=haswell
 LTO_LD_FLAGS=-flto=auto -ffat-lto-objects -Wl,-plugin-opt=-march=haswell

--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -431,3 +431,12 @@ RUN if [ -f /usr/bin/dnf ] ; then export DNF_TOOL=dnf ; \
 
 USER ovms
 ENTRYPOINT ["/ovms/bin/ovms"]
+
+LABEL name="rhoai/odh-openvino-model-server-rhel9" \
+      com.redhat.component="odh-openvino-model-server-rhel9" \
+      io.k8s.display-name="odh-openvino-model-server-rhel9" \
+      io.k8s.description="OpenVINO Model Server (OVMS) is a high-performance system for serving models." \
+      description="OpenVINO Model Server (OVMS) is a high-performance system for serving models." \
+      summary="OpenVINO Model Server (OVMS) is a high-performance system for serving models." \
+      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf" \
+         vendor="Red Hat, Inc."

--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -289,6 +289,7 @@ RUN bazel build --jobs=$JOBS ${debug_bazel_flags} //src:release_custom_nodes
 
 # OVMS
 ARG OPTIMIZE_BUILDING_TESTS=0
+RUN rm -f /usr/lib64/cmake/OpenSSL/OpenSSLConfig.cmake
 # Builds unit tests together with ovms server in one step
 # It speeds up CI when tests are executed outside of the image building
 # hadolint ignore=SC2046

--- a/OWNERS
+++ b/OWNERS
@@ -13,5 +13,5 @@ reviewers:
   - Raghul-M
   - Jooho
   - brettmthompson
-  - edwardquarmi
+  - edwardquarm
   - Snomaan6846

--- a/OWNERS
+++ b/OWNERS
@@ -5,7 +5,7 @@ approvers:
   - Raghul-M
   - Jooho
   - brettmthompson
-  - edwardquarmi
+  - edwardquarm
   - Snomaan6846
 reviewers:
   - RH-steve-grubb

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,17 @@
+approvers:
+  - danielezonca
+  - RH-steve-grubb
+  - rpancham
+  - Raghul-M
+  - Jooho
+  - brettmthompson
+  - edwardquarmi
+  - Snomaan6846
+reviewers:
+  - RH-steve-grubb
+  - rpancham
+  - Raghul-M
+  - Jooho
+  - brettmthompson
+  - edwardquarmi
+  - Snomaan6846


### PR DESCRIPTION
This patch updates to UBI 9.7 to fix CVE's. It also fixes a couple build issues and updates python modules to also get rid of CVEs'.