### PR TITLE
Pin wheel<0.38.0

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -174,7 +174,7 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.n
     dnf clean all
 # hadolint ignore=DL3003
 RUN if [ "$ov_use_binary" == "0" ] ; then true ; else exit 0 ; fi ; git clone https://github.com/$ov_source_org/openvino.git /openvino && cd /openvino && git checkout $ov_source_branch && git submodule update --init --recursive
-RUN if [ "$ov_use_binary" == "0" ]; then true ; else exit 0 ; fi ; if ! [[ $debug_bazel_flags == *"py_off"* ]]; then true ; else exit 0 ; fi ; pip3 install --no-cache-dir -r /openvino/src/bindings/python/wheel/requirements-dev.txt
+RUN if [ "$ov_use_binary" == "0" ]; then true ; else exit 0 ; fi ; if ! [[ $debug_bazel_flags == *"py_off"* ]]; then true ; else exit 0 ; fi ; pip3 install --no-cache-dir "wheel<0.38.0" && pip3 install --no-cache-dir -r /openvino/src/bindings/python/wheel/requirements-dev.txt
 
 WORKDIR /openvino/build
 RUN if [ "$ov_use_binary" == "0" ] && [[ $debug_bazel_flags == *"PYTHON_DISABLE=1"* ]]; then true ; else exit 0 ; fi ; if ! [[ $debug_bazel_flags == *"PYTHON_DISABLE=1"* ]]; then true ; else exit 0 ; fi ; cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DENABLE_LTO=${LTO_ENABLE} -DENABLE_PYTHON=ON -DENABLE_INTEL_NPU=OFF -DENABLE_SAMPLES=0 -DCMAKE_CXX_FLAGS=" -Wno-error=parentheses  ${LTO_CXX_FLAGS} " -DCMAKE_SHARED_LINKER_FLAGS="${LTO_LD_FLAGS}" ..


### PR DESCRIPTION
Root Cause:The build fails because wheel-0.46.3 is installed, but OpenVINO's CMakeLists.txt expects wheel.vendored.packaging.tags, which was removed in wheel>=0.38.0 (released in 2023).

Why it broke:The OpenVINO requirements-dev.txt doesn't pin wheel, so pip installs the latest (0.46.3), which is incompatible with OpenVINO's CMake code.

We are using a commit to install openvino c01cd93e24d1cd78bfbb401eed51c08fb93e0816

Openvino fixes this in latest commit in main: https://github.com/openvinotoolkit/openvino/commit/6bf892155e3f11dde49478c94dae9b6b3618b93a