### PR TITLE
Correct	the tokenizer version

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -226,7 +226,7 @@ ARG SDL_OPS="-fpic -O2 -U_FORTIFY_SOURCE -fstack-protector -fno-omit-frame-point
 # hadolint ignore=DL3003
 RUN if ! [[ $debug_bazel_flags == *"_py_off"* ]]; then \  
 # python tokenizers built always from source because it is not in binary package
-    git clone https://github.com/$ov_tokenizers_org/openvino_tokenizers.git /openvino_tokenizers && cd /openvino_tokenizers && git checkout 85be884a69f10270703f81f970a5ee596a4c8df7 && git submodule update --init --recursive && \
+    git clone https://github.com/$ov_tokenizers_org/openvino_tokenizers.git /openvino_tokenizers && cd /openvino_tokenizers && git checkout e79796a77f3212bc69466be54d05ed04f0a6ffd8 && git submodule update --init --recursive && \
     sed -i '/openvino~=/d' /openvino_tokenizers/pyproject.toml && \
     sed -i '/requires-python/d' /openvino_tokenizers/pyproject.toml && \
     cd /openvino_tokenizers && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DCMAKE_CXX_FLAGS=" ${SDL_OPS} ${LTO_CXX_FLAGS} " -DCMAKE_SHARED_LINKER_FLAGS="${LTO_LD_FLAGS}" -S ./ -B ./build/  && cmake --build ./build/ --parallel $JOBS && cp /openvino_tokenizers/build/src/lib*.so /opt/intel/openvino/runtime/lib/intel64/ && \

--- a/Dockerfile.redhat
+++ b/Dockerfile.redhat
@@ -227,7 +227,7 @@ ARG SDL_OPS="-fpic -O2 -U_FORTIFY_SOURCE -fstack-protector -fno-omit-frame-point
 
 RUN if ! [[ $debug_bazel_flags == *"_py_off"* ]]; then \  
 # python tokenizers built always from source because it is not in binary package
-    git clone https://github.com/$ov_tokenizers_org/openvino_tokenizers.git /openvino_tokenizers && cd /openvino_tokenizers && git checkout 85be884a69f10270703f81f970a5ee596a4c8df7 && git submodule update --init --recursive && \
+    git clone https://github.com/$ov_tokenizers_org/openvino_tokenizers.git /openvino_tokenizers && cd /openvino_tokenizers && git checkout e79796a77f3212bc69466be54d05ed04f0a6ffd8 && git submodule update --init --recursive && \
     sed -i '/openvino~=/d' /openvino_tokenizers/pyproject.toml && \
     sed -i '/requires-python/d' /openvino_tokenizers/pyproject.toml && \
     cd /openvino_tokenizers && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_LOGS}" -DCMAKE_CXX_FLAGS=" ${SDL_OPS} ${LTO_CXX_FLAGS} " -DCMAKE_SHARED_LINKER_FLAGS="${LTO_LD_FLAGS}" -S ./ -B ./build/  && cmake --build ./build/ --parallel $JOBS && cp /openvino_tokenizers/build/src/lib*.so /opt/intel/openvino/runtime/lib/intel64/ && \


### PR DESCRIPTION
Upstream bumped some components to 2025.4.2. The fix was to checkout at the exact commit for the 2025.4.1 release. The default one in the Dockerfile was used by accident. This corrects the	checkout to be 2025.4.1.

(cherry picked from commit f9da2286a1d60aacbd2b0c2726eeb1b7872679e8)
